### PR TITLE
getTasksByFilter ignores filters beside the predefined ones

### DIFF
--- a/src/Torann/LaravelAsana/Asana.php
+++ b/src/Torann/LaravelAsana/Asana.php
@@ -242,13 +242,11 @@ class Asana
      */
     public function getTasksByFilter($filter = ["assignee" => "", "project" => "", "workspace" => ""])
     {
-        $url = "";
-        $filter = array_merge(["assignee" => "", "project" => "", "workspace" => ""], $filter);
-        $url .= $filter["assignee"] != "" ? "&assignee={$filter["assignee"]}" : "";
-        $url .= $filter["project"] != "" ? "&project={$filter["project"]}" : "";
-        $url .= $filter["workspace"] != "" ? "&workspace={$filter["workspace"]}" : "";
-        if (strlen($url) > 0) $url = "?" . substr($url, 1);
-
+        $filter = array_filter(array_merge(["assignee" => "", "project" => "", "workspace" => ""], $filter));
+        $url = '?' . join('&', array_map(function($k, $v){
+            return "{$k}={$v}";
+        }, array_keys($filter), $filter));
+        
         return $this->curl->get("tasks{$url}");
     }
 


### PR DESCRIPTION
`$url` was built upon only the three array keys specified and the content of the correctly merged `$filter` array was ignored.
Now `$url` is built upon every filter in `$filter`.
